### PR TITLE
Update kraken2otu.py

### DIFF
--- a/kraken2otu.py
+++ b/kraken2otu.py
@@ -74,8 +74,7 @@ def read_in_files(directory: str, extension=args.extension) -> Dict:
 
     for file in report_files:
         file = os.path.abspath(file)
-        file_dictionary[os.path.basename(file).rstrip(
-            f"{extension}")] = extract(file)
+        file_dictionary[os.path.basename(file).removesuffix(extension)] = extract(file)
 
     return file_dictionary
 


### PR DESCRIPTION
The line "key = os.path.basename(file).rstrip(f'{extension}') " strip the .k2report extension from the filename.  However, rstrip() removes all trailing characters that match any character in the argument string, not just the exact sequence.  For example if you have a file whose name is "Sample2.k2report" , rstrip() removes either the "2" character and the output will be "Sample" instead of Sample2. (If there are any characters in the basename that match characters in .k2report, it could inadvertently remove them). For this reason i changed the rstrip function with removesuffix()  which will correctly remove the suffix.